### PR TITLE
Add link to history

### DIFF
--- a/templates/diff.html
+++ b/templates/diff.html
@@ -8,6 +8,7 @@
 {% endblock %}
 {% block main %}
 <h2><a href="https://www.wikidata.org/wiki/{{ title }}">{{ title }}</a></h2>
+<p>(<a href="https://www.wikidata.org/w/index.php?title={{ title }}&action=history">history</a>)</p>
 <table class="diff">
   <colgroup>
     <col class="diff-marker">

--- a/templates/diff.html
+++ b/templates/diff.html
@@ -7,8 +7,10 @@
 <link rel="stylesheet" href="https://www.wikidata.org/w/load.php?modules=mediawiki.legacy.shared|mediawiki.diff.styles|wikibase.common&only=styles">
 {% endblock %}
 {% block main %}
-<h2><a href="https://www.wikidata.org/wiki/{{ title }}">{{ title }}</a></h2>
-<p>(<a href="https://www.wikidata.org/w/index.php?title={{ title }}&action=history">history</a>)</p>
+<h2>
+  <a href="https://www.wikidata.org/wiki/{{ title }}">{{ title }}</a>
+  <span class="text-muted">(<a href="https://www.wikidata.org/w/index.php?title={{ title }}&action=history">history</a>)</span>
+</h2>
 <table class="diff">
   <colgroup>
     <col class="diff-marker">


### PR DESCRIPTION
Nice tool! I just found myself needing to check out the history of an item to understand better an edit, so I thought it could be worth putting a direct link on the tool. Feel free to rearrange the layout - ideally I would have put it on the right of the Qid in `<h2>` I think, but I don't want to mess up with your CSS :)