### PR TITLE
Settings link should be visible only for login users

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,11 +7,11 @@
   </p>
   {% if user_logged_in() %}
   <a class="btn btn-primary btn-large" href="{{ url_for('any_diff') }}">Start</a>
+  <a class="btn btn-secondary btn-large" href="{{ url_for('settings') }}">Settings</a>
   {% else %}
   <p>
     <a class="btn btn-primary btn-large" href="{{ url_for('login') }}">Log in</a> to get started
   </p>
   {% endif %}
-  <a class="btn btn-secondary btn-large" href="{{ url_for('settings') }}">Settings</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
Currently, https://tools.wmflabs.org/speedpatrolling/settings/ giving Internal Server Error.